### PR TITLE
Fixed game screenshots page.

### DIFF
--- a/_layouts/screenshots.html
+++ b/_layouts/screenshots.html
@@ -1,5 +1,6 @@
 ---
 aside: screenshots_aside.html
+layout: default
 ---
 
 <br />


### PR DESCRIPTION
It was blank. Now with _clear_ layout.

It seems default layout doesn't affect generated data pages.
https://github.com/indrakaw/www.queenscourt.org/blob/c92e76765db555ab5cc9c40dc36481abaa3b5e65/_config.yml#L28